### PR TITLE
Space behind Search Button

### DIFF
--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -58,7 +58,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 				</div>
 				<?php endif; ?>
 				<span class="input-group-append">
-					<button type="submit" class="btn btn-primary" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
+					<button type="submit" class="btn btn-primary mr-2" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
 						<span class="fas fa-search" aria-hidden="true"></span>
 					</button>
 				</span>


### PR DESCRIPTION
### Summary of Changes

With this change there is the same space behind the search button like behind the Filter Options:
![Articles  Fields   test   Administration](https://user-images.githubusercontent.com/9974686/75112000-0e895b80-5640-11ea-8c6f-f5d6dc417477.png)

Here is no space:
![Articles  Fields   test   Administration(1)](https://user-images.githubusercontent.com/9974686/75112003-0fba8880-5640-11ea-84b3-efceda76e177.png)

